### PR TITLE
[ask] Add a sync publisher for configuration events

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+---
+version: '3'
+
+services:
+  broker:
+    image: rabbitmq:3.9-management-alpine
+    ports:
+      - "5672:5672"
+      - "15672:15672"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,8 @@ services:
     ports:
       - "5672:5672"
       - "15672:15672"
+
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379:6379"

--- a/src/eventail/sync_publisher.py
+++ b/src/eventail/sync_publisher.py
@@ -128,7 +128,6 @@ class Endpoint:
         self,
         event: str,
         message: JSON_MODEL,
-        conversation_id: str,
         max_retries: Optional[int] = None,
     ) -> None:
         """Publish a configuration event on the bus.
@@ -141,14 +140,13 @@ class Endpoint:
         """
 
         with producers[self._connection].acquire(block=True, timeout=2) as producer:
-            headers = {"conversation_id": str(conversation_id)}
             producer.publish(
                 message if self._force_json else cbor.dumps(message),
                 delivery_mode=1,  # not persistent
                 exchange=self.configuration_exchange,
                 routing_key=event,
                 declare=[self.configuration_exchange],
-                headers=headers,
+                headers={},
                 content_type=None if self._force_json else "application/cbor",
                 content_encoding=None if self._force_json else "binary",
                 serializer="json" if self._force_json else None,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -41,6 +41,3 @@ class TestSTDataStore(TestCase):
 
     def test_is_down(self):
         self.assertEqual(self.tmp_store.is_down(), "")
-
-
-


### PR DESCRIPTION
Story details: https://app.shortcut.com/allomedia/story/25791

I added a `docker-compose.yml` file to simplify the running of a RabbitMQ broker.
This is a copy/paste of the `publish_event` code but with non persistent durability and another exchange.