### PR TITLE
Use empty list as monitor default value for commands, configurations and events

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     docker:
       - image: cimg/python:3.8
-      - image: redis:4.0.11-alpine
+      - image: cimg/redis:5.0
         name: redis
 
     working_directory: ~/async-service
@@ -14,8 +14,7 @@ jobs:
 
       # Download and cache dependencies
       - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+          key: env-{{ .Environment.CACHE_VERSION }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
       - run:
           name: install tox
@@ -23,28 +22,28 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install -e .
-            pip install tox==3.25.1
+            pip install tox
+            tox --notest  # Install all tox dependencies
 
       - save_cache:
+          key: env-{{ .Environment.CACHE_VERSION }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
           paths:
             - ./venv
             - .tox
-
-          key: v1-dependencies-{{ checksum "setup.py" }}
 
       # run linters!
       - run:
           name: run linters
           command: |
             . venv/bin/activate
-            tox mypy,flake8
+            tox -e mypy,flake8
 
       # run tests!
       - run:
           name: run tests
           command: |
             . venv/bin/activate
-            tox py3
+            tox -e py3
 
       # test scripts
       - run:
@@ -61,7 +60,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
 
     working_directory: ~/eventail
 

--- a/scripts/monitor.py
+++ b/scripts/monitor.py
@@ -136,19 +136,19 @@ if __name__ == "__main__":
         "--events",
         help="Event patterns to subscribe to (default to none)",
         nargs="*",
-        default=["none"],
+        default=[],
     )
     parser.add_argument(
         "--commands",
         help="Command patterns to subscribe to (default to none)",
         nargs="*",
-        default=["none"],
+        default=[],
     )
     parser.add_argument(
         "--configurations",
         help="Configuration patterns to subscribe to (default to none)",
         nargs="*",
-        default=["none"],
+        default=[],
     )
     parser.add_argument(
         "--save", action="store_true", help="save payloads in CBOR format."

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="eventail",
-    version="2.2.3",
+    version="2.2.4",
     url="https://github.com/allo-media/eventail",
     author="Allo-Media",
     author_email="dev@allo-media.fr",

--- a/src/eventail/async_service/aio/base.py
+++ b/src/eventail/async_service/aio/base.py
@@ -264,7 +264,7 @@ class Service:
                         content_type=self._mime_type,
                         reply_to=reply_to,
                         correlation_id=correlation_id,
-                        headers=headers, # type: ignore
+                        headers=headers,  # type: ignore
                     ),
                 )
             except exceptions.DeliveryError as e:


### PR DESCRIPTION
The change introduced in #63 sets the monitor default value to `['none']`, which means that we monitor the routing key `none`. We should use an empty list to effectively monitor nothing.
This was discovered while testing topic permissions: we have very restricted permissions on a topic and the monitor command failed immediately because RabbitMQ refused to monitor for the `none` routing key:
> Channel 1 was closed: (403, "ACCESS_REFUSED - access to topic 'none' in exchange 'events' in vhost 'services' refused for user 'XXX")