### PR TITLE
[ask] Redact auth from amqp URL

### DIFF
--- a/src/eventail/async_service/aio/base.py
+++ b/src/eventail/async_service/aio/base.py
@@ -54,7 +54,6 @@ HEADER = Dict[str, str]
 
 
 class Service:
-
     ID = os.getpid()
     HOSTNAME = socket.gethostname()
     EVENT_EXCHANGE = "events"
@@ -114,7 +113,6 @@ class Service:
             self.stopped.set()
 
     async def on_message(self, message: DeliveredMessage) -> None:
-
         properties = message.header.properties
 
         headers: Dict[str, Any] = properties.headers or {}

--- a/src/eventail/async_service/pika/base.py
+++ b/src/eventail/async_service/pika/base.py
@@ -38,8 +38,6 @@ import traceback
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, Generator, List, Optional, Sequence, Tuple
 
-from pip._internal.utils.misc import redact_auth_from_url
-
 import cbor
 import pika
 
@@ -165,7 +163,7 @@ class Service(object):
         self.reset_connection_state()
         url = self._urls[self.url_idx]
         self.url_idx = (self.url_idx + 1) % len(self._urls)
-        LOGGER.info("Connecting to %s", redact_auth_from_url(url))
+        LOGGER.info("Connecting to %s", url.split("@")[-1])
         connection_params = pika.URLParameters(url)
         connection_params.heartbeat = self.HEARTBEAT
         connection_params.blocked_connection_timeout = self.BLOCKED_TIMEOUT

--- a/src/eventail/async_service/pika/base.py
+++ b/src/eventail/async_service/pika/base.py
@@ -38,6 +38,8 @@ import traceback
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, Generator, List, Optional, Sequence, Tuple
 
+from pip._internal.utils.misc import redact_auth_from_url
+
 import cbor
 import pika
 
@@ -163,7 +165,7 @@ class Service(object):
         self.reset_connection_state()
         url = self._urls[self.url_idx]
         self.url_idx = (self.url_idx + 1) % len(self._urls)
-        LOGGER.info("Connecting to %s", url)
+        LOGGER.info("Connecting to %s", redact_auth_from_url(url))
         connection_params = pika.URLParameters(url)
         connection_params.heartbeat = self.HEARTBEAT
         connection_params.blocked_connection_timeout = self.BLOCKED_TIMEOUT


### PR DESCRIPTION
We should redact the amqp URL to remove the password before logging.

We use an internal helper from pip to do this: https://github.com/pypa/pip/blob/0827d76bd2987ddea6f327e0c24e821d27d71cdf/src/pip/_internal/utils/misc.py#L576
We could implement it by ourselves but its not that simple