### PR TITLE
[shilp] JSON serialization fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="eventail",
-    version="2.3.5",
+    version="2.3.6",
     url="https://github.com/allo-media/eventail",
     author="Allo-Media",
     author_email="dev@allo-media.fr",

--- a/src/eventail/async_service/pika/base.py
+++ b/src/eventail/async_service/pika/base.py
@@ -854,7 +854,7 @@ class Service(object):
 
     def use_json(self) -> None:
         """Force sending message serialized in plain JSON instead of CBOR."""
-        self._serialize = lambda message: json.dumps(message).encode("utf-8")
+        self._serialize = lambda message: json.dumps(message, ensure_ascii=False).encode("utf-8")
         self._mime_type = "application/json"
 
     def use_exclusive_queues(self) -> None:


### PR DESCRIPTION
JSON strings must be serialized as UTF-8 to remain consistent with CBOR.